### PR TITLE
feat: declare the model catalog and per-node model_usage

### DIFF
--- a/griptape_nodes_library_blackforestlabs/griptape_nodes_library.json
+++ b/griptape_nodes_library_blackforestlabs/griptape_nodes_library.json
@@ -1,6 +1,6 @@
 {
   "name": "Black Forest Labs Library",
-  "library_schema_version": "0.1.0",
+  "library_schema_version": "0.10.0",
   "settings": [
     {
       "description": "API keys required by nodes in this library",
@@ -14,7 +14,7 @@
     "author": "Griptape",
     "description": "Griptape Nodes for Black Forest Labs APIs including FLUX.1 Kontext and FLUX text-to-image generation and image editing",
     "library_version": "0.2.1",
-    "engine_version": "0.75.0",
+    "engine_version": "0.92.0",
     "tags": [
       "Griptape",
       "AI",
@@ -23,6 +23,84 @@
       "Image Generation",
       "Image Editing",
       "Text-to-Image"
+    ],
+    "declarations": [
+      {
+        "type": "model_catalog",
+        "providers": {
+          "black_forest_labs": {
+            "display_name": "Black Forest Labs",
+            "models": {
+              "bfl_flux_2_klein_4b": {
+                "display_name": "FLUX.2 Klein 4B",
+                "family": "FLUX.2",
+                "provider_model_id": "flux-2-klein-4b",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "bfl_flux_2_klein_9b": {
+                "display_name": "FLUX.2 Klein 9B",
+                "family": "FLUX.2",
+                "provider_model_id": "flux-2-klein-9b",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "bfl_flux_kontext_pro": {
+                "display_name": "FLUX Kontext Pro",
+                "family": "FLUX Kontext",
+                "provider_model_id": "flux-kontext-pro",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "bfl_flux_kontext_max": {
+                "display_name": "FLUX Kontext Max",
+                "family": "FLUX Kontext",
+                "provider_model_id": "flux-kontext-max",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "bfl_flux_pro_1_1_ultra": {
+                "display_name": "FLUX Pro 1.1 Ultra",
+                "family": "FLUX Pro",
+                "provider_model_id": "flux-pro-1.1-ultra",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "bfl_flux_pro_1_1": {
+                "display_name": "FLUX Pro 1.1",
+                "family": "FLUX Pro",
+                "provider_model_id": "flux-pro-1.1",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "bfl_flux_pro": {
+                "display_name": "FLUX Pro",
+                "family": "FLUX Pro",
+                "provider_model_id": "flux-pro",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "bfl_flux_dev": {
+                "display_name": "FLUX Dev",
+                "family": "FLUX Dev",
+                "provider_model_id": "flux-dev",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "bfl_flux_2_pro": {
+                "display_name": "FLUX.2 Pro",
+                "family": "FLUX.2",
+                "provider_model_id": "flux-2-pro",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "bfl_flux_2_flex": {
+                "display_name": "FLUX.2 Flex",
+                "family": "FLUX.2",
+                "provider_model_id": "flux-2-flex",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "bfl_flux_pro_1_0_fill": {
+                "display_name": "FLUX Pro 1.0 Fill",
+                "family": "FLUX Fill",
+                "provider_model_id": "flux-pro-1.0-fill",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              }
+            }
+          }
+        }
+      }
     ]
   },
   "categories": [
@@ -42,7 +120,13 @@
       "metadata": {
         "category": "image/black_forest_labs",
         "description": "Combine an image, a mask and a text prompt to create a new image",
-        "display_name": "FLUX Fill"
+        "display_name": "FLUX Fill",
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": ["bfl_flux_pro_1_0_fill"]
+          }
+        ]
       }
     },
     {
@@ -51,7 +135,22 @@
       "metadata": {
         "category": "image/black_forest_labs",
         "description": "Generate high-quality images from text prompts using FLUX Pro, Dev, and Ultra models",
-        "display_name": "FLUX Text-to-Image"
+        "display_name": "FLUX Text-to-Image",
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "bfl_flux_2_klein_4b",
+              "bfl_flux_2_klein_9b",
+              "bfl_flux_kontext_pro",
+              "bfl_flux_kontext_max",
+              "bfl_flux_pro_1_1_ultra",
+              "bfl_flux_pro_1_1",
+              "bfl_flux_pro",
+              "bfl_flux_dev"
+            ]
+          }
+        ]
       }
     },
     {
@@ -60,7 +159,13 @@
       "metadata": {
         "category": "image/black_forest_labs",
         "description": "Edit existing images using FLUX.1 Kontext with text prompts for object modification, text editing, and smart changes",
-        "display_name": "FLUX.1 Kontext Image Edit"
+        "display_name": "FLUX.1 Kontext Image Edit",
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": ["bfl_flux_kontext_pro", "bfl_flux_kontext_max"]
+          }
+        ]
       }
     },
     {
@@ -69,7 +174,13 @@
       "metadata": {
         "category": "image/black_forest_labs",
         "description": "Generate images using FLUX 2 Pro and Flex models with support for text-to-image and image-to-image",
-        "display_name": "FLUX 2 Image Generation"
+        "display_name": "FLUX 2 Image Generation",
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": ["bfl_flux_2_pro", "bfl_flux_2_flex"]
+          }
+        ]
       }
     }
   ]

--- a/tests/unit/test_model_catalog_consistency.py
+++ b/tests/unit/test_model_catalog_consistency.py
@@ -1,0 +1,174 @@
+"""Keep the `model_catalog` declarations in sync with the model lists the
+library actually serves.
+
+The catalog is the contract the library exposes to the platform (policy, key
+support, UI grouping). Each node carries its served model list statically in
+Python -- either as literal `Options(choices=[...])` values on the "model"
+parameter, a module-level constant referenced from that trait, or (for
+`FluxFill`) a single fixed provider model id with no dropdown at all. The
+catalog and the served models must agree, and these tests are the guard that
+keeps them from drifting.
+
+The model lists are read directly from each node's source via `ast` rather
+than importing the node modules. Importing pulls in the full `griptape_nodes`
+engine package, which these tests don't otherwise need; parsing the source
+keeps the check self-contained and immune to unrelated import-time failures.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).parents[2]
+LIBRARY_DIR = REPO_ROOT / "griptape_nodes_library_blackforestlabs"
+LIBRARY_JSON = LIBRARY_DIR / "griptape_nodes_library.json"
+
+# FluxFill has no "model" dropdown -- it always calls a single fixed BFL
+# endpoint. The id is a literal baked into `_create_request` and
+# `_create_image_artifact`, not a named constant.
+FLUX_FILL_FIXED_MODEL = "flux-pro-1.0-fill"
+
+
+def _load_library() -> dict[str, Any]:
+    return json.loads(LIBRARY_JSON.read_text())
+
+
+def _provider_model_id_by_catalog_id(library: dict[str, Any]) -> dict[str, str]:
+    """Map every catalog model id to its provider_model_id, across all providers."""
+    catalog = next(d for d in library["metadata"]["declarations"] if d["type"] == "model_catalog")
+    return {
+        model_id: model["provider_model_id"]
+        for provider in catalog["providers"].values()
+        for model_id, model in provider["models"].items()
+    }
+
+
+def _model_usage_ids(library: dict[str, Any], class_name: str) -> list[str]:
+    node = next(n for n in library["nodes"] if n["class_name"] == class_name)
+    usage = next(d for d in node["metadata"]["declarations"] if d["type"] == "model_usage")
+    return usage["model_ids"]
+
+
+def _nodes_with_model_usage(library: dict[str, Any]) -> list[str]:
+    """Class names of every node that declares `model_usage`."""
+    return [
+        node["class_name"]
+        for node in library["nodes"]
+        if any(d.get("type") == "model_usage" for d in node.get("metadata", {}).get("declarations", []))
+    ]
+
+
+def _top_level_constants(tree: ast.Module) -> dict[str, Any]:
+    """Map every top-level `NAME = <literal>` assignment to its literal value."""
+    constants: dict[str, Any] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+            try:
+                constants[node.targets[0].id] = ast.literal_eval(node.value)
+            except ValueError:
+                continue
+    return constants
+
+
+def _model_choices_from_source(file_path: Path, *, param_name: str = "model") -> list[str]:
+    """Extract the `Options(choices=...)` list on a node's model Parameter.
+
+    Finds the `Parameter(name=param_name, ...)` call, reads the `Options`
+    trait's `choices` argument, and resolves it to a literal list -- whether
+    it's written inline or as a reference to a module-level constant.
+    """
+    tree = ast.parse(file_path.read_text())
+    constants = _top_level_constants(tree)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name_kwarg = next(
+            (kw for kw in node.keywords if kw.arg == "name" and isinstance(kw.value, ast.Constant)),
+            None,
+        )
+        if name_kwarg is None or name_kwarg.value.value != param_name:
+            continue
+
+        traits_kwarg = next((kw for kw in node.keywords if kw.arg == "traits"), None)
+        if traits_kwarg is None:
+            continue
+
+        for options_call in ast.walk(traits_kwarg.value):
+            if not (isinstance(options_call, ast.Call) and isinstance(options_call.func, ast.Name)):
+                continue
+            if options_call.func.id != "Options":
+                continue
+            choices_kwarg = next((kw for kw in options_call.keywords if kw.arg == "choices"), None)
+            if choices_kwarg is None:
+                continue
+            if isinstance(choices_kwarg.value, ast.Name):
+                return list(constants[choices_kwarg.value.id])
+            return list(ast.literal_eval(choices_kwarg.value))
+
+    msg = f"Could not find an Options(choices=...) trait for parameter '{param_name}' in {file_path}"
+    raise AssertionError(msg)
+
+
+@pytest.mark.parametrize(
+    ("class_name", "file_name"),
+    [
+        ("TextToImage", "text_to_image.py"),
+        ("KontextImageEdit", "kontext_image_edit.py"),
+        ("Flux2ImageGeneration", "flux_2_image_generation.py"),
+    ],
+)
+def test_dropdown_node_model_usage_matches_source_choices(class_name: str, file_name: str) -> None:
+    """The model dropdown in Python and the models the node declares must agree.
+
+    Each node's `model_usage` ids resolve (through the catalog) to the same
+    ordered provider model ids the node's `model` parameter actually offers.
+    A mismatch means the manifest and the code drifted and one side needs
+    updating.
+    """
+    library = _load_library()
+    provider_model_id_by_catalog_id = _provider_model_id_by_catalog_id(library)
+
+    declared = [provider_model_id_by_catalog_id[model_id] for model_id in _model_usage_ids(library, class_name)]
+    served = _model_choices_from_source(LIBRARY_DIR / file_name)
+
+    assert declared == served
+
+
+def test_flux_fill_model_usage_matches_fixed_endpoint() -> None:
+    """FluxFill has no dropdown -- it declares its single fixed BFL endpoint."""
+    library = _load_library()
+    provider_model_id_by_catalog_id = _provider_model_id_by_catalog_id(library)
+
+    declared = [provider_model_id_by_catalog_id[model_id] for model_id in _model_usage_ids(library, "FluxFill")]
+
+    assert declared == [FLUX_FILL_FIXED_MODEL]
+    assert FLUX_FILL_FIXED_MODEL in (LIBRARY_DIR / "flux_fill.py").read_text()
+
+
+def test_declared_models_resolve_uniquely_per_node() -> None:
+    """Each node's declared models map one-to-one to provider model ids.
+
+    Code that resolves a selected provider model id back to its stable
+    catalog key (e.g. to declare a model invocation) matches within the
+    node's own declared models. That match is unambiguous only when a node
+    does not declare two catalog ids that share a `provider_model_id`; a
+    duplicate would make the runtime resolver fail closed. Guard the
+    manifest against introducing one.
+    """
+    library = _load_library()
+    provider_model_id_by_catalog_id = _provider_model_id_by_catalog_id(library)
+
+    duplicates: dict[str, list[str]] = {}
+    for class_name in _nodes_with_model_usage(library):
+        wire_ids = [provider_model_id_by_catalog_id[model_id] for model_id in _model_usage_ids(library, class_name)]
+        repeated = sorted({wire_id for wire_id in wire_ids if wire_ids.count(wire_id) > 1})
+        if repeated:
+            duplicates[class_name] = repeated
+
+    assert not duplicates, f"nodes declare catalog ids that share a provider_model_id: {duplicates}"


### PR DESCRIPTION
Part of griptape-ai/internal#172, closes part of #29 (phase 1 of 3).

First step of adopting the model-governance declarations the standard library established (griptape-ai/griptape-nodes-library-standard#338, #353). This library predates all of it, so platform consumers (policy, admin, UI) can't see what models it invokes.

Declares a `model_catalog` with a `black_forest_labs` provider (11 models, all `REQUIRES_CUSTOMER_KEY` since the nodes call the BFL API directly with `BFL_API_KEY`), adds `model_usage` to all four nodes, and bumps the schema to 0.10.0 / engine pin to 0.92.0. Stable ids use a `bfl_` prefix rather than the standard library's `gtc_`: catalogs are library-local, and the `gtc_flux_*` entries describe Griptape-Cloud-proxied routing while these are direct BYOK calls, so they are deliberately distinct catalog identities.

Metadata only; no node behavior changes. A consistency test guards each node's declared ids against its served model list.